### PR TITLE
Maintain order of styles passed to CompositeStyle

### DIFF
--- a/core/src/main/java/org/subtlelib/poi/impl/style/CompositeStyle.java
+++ b/core/src/main/java/org/subtlelib/poi/impl/style/CompositeStyle.java
@@ -1,7 +1,7 @@
 package org.subtlelib.poi.impl.style;
 
 import java.util.Collection;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -21,7 +21,7 @@ public final class CompositeStyle implements AdditiveStyle {
 	private final ImmutableMap<Enum<?>, AdditiveStyle> styles;
 	
     public CompositeStyle(List<AdditiveStyle> partialStyles) {
-        Map<Enum<?>, AdditiveStyle> combined = new HashMap<>();
+        Map<Enum<?>, AdditiveStyle> combined = new LinkedHashMap<>();
         for (AdditiveStyle partialStyle : partialStyles) {
             combined.put(partialStyle.getType(), partialStyle);
         }

--- a/core/src/test/java/org/subtlelib/poi/impl/style/StylesInternalTest.java
+++ b/core/src/test/java/org/subtlelib/poi/impl/style/StylesInternalTest.java
@@ -3,6 +3,8 @@ package org.subtlelib.poi.impl.style;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
 import org.junit.Test;
 import org.subtlelib.poi.api.style.AdditiveStyle;
 import org.subtlelib.poi.api.style.Style;
@@ -10,13 +12,16 @@ import org.subtlelib.poi.fixtures.AdditiveStyleTestImpl;
 import org.subtlelib.poi.fixtures.NonAdditiveStyleTestImpl;
 import org.subtlelib.poi.fixtures.StyleType;
 
+import java.util.Collection;
+
+
 /**
  * Created on 10/04/13
  * @author d.serdiuk
  */
 public class StylesInternalTest {
     AdditiveStyle additive = new AdditiveStyleTestImpl("additive", StyleType.type1);
-    AdditiveStyle additive2 = new AdditiveStyleTestImpl("additive", StyleType.type1);
+    AdditiveStyle additive2 = new AdditiveStyleTestImpl("additive2", StyleType.type2);
     Style nonAdditive = new NonAdditiveStyleTestImpl("non-additive");
     Style nonAdditive2 = new NonAdditiveStyleTestImpl("non-additive2");
 
@@ -54,5 +59,16 @@ public class StylesInternalTest {
 
         // verify
         assertTrue(result instanceof CompositeStyle);
+    }
+
+    @Test
+    public void testCombineOrOverride_bothAdditive_stylesReturnedInTheSameOrderAsAdded() {
+        // do
+        Style result = StylesInternal.combineOrOverride(additive, additive2);
+
+        // verify
+        Collection<AdditiveStyle> styles = ((CompositeStyle) result).getStyles();
+        assertEquals(true,
+                Iterables.elementsEqual(ImmutableList.of(additive, additive2), styles));
     }
 }


### PR DESCRIPTION
This fix will make sure that if two styles setting the same property are combined then the last added style will override the property value.
