### PR TITLE
making the library JDK 1.6 compatible and compiling for JDK 1.6

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -43,5 +43,18 @@
             <artifactId>mockito-all</artifactId>
         </dependency>
     </dependencies>
+    
+    <build>
+    	<plugins>
+	        <plugin>
+	          <artifactId>maven-compiler-plugin</artifactId>
+	          <configuration>
+	            <source>1.6</source>
+	            <target>1.6</target>
+	            <fork>true</fork>
+	          </configuration>
+	        </plugin>
+    	</plugins>
+    </build>
 
 </project>

--- a/core/src/main/java/org/subtlelib/poi/api/style/Styles.java
+++ b/core/src/main/java/org/subtlelib/poi/api/style/Styles.java
@@ -29,7 +29,7 @@ public class Styles {
             return styles.get(0);
         }
 
-        List<AdditiveStyle> parts = new ArrayList<>();
+        List<AdditiveStyle> parts = new ArrayList<AdditiveStyle>();
         for (AdditiveStyle style : styles) {
             // can't use polymorphism in this case since we want to keep AdditiveStyle an interface so
             // that it can be implemented by user enums

--- a/core/src/main/java/org/subtlelib/poi/api/workbook/WorkbookContext.java
+++ b/core/src/main/java/org/subtlelib/poi/api/workbook/WorkbookContext.java
@@ -28,7 +28,7 @@ public interface WorkbookContext extends ConfigurationProvider, StyleRegistry, S
 	 * @throws java.lang.IllegalArgumentException if a sheet with the given name doesn't exist
 	 */
 	public SheetContext useSheet(String sheetName); 
-	
+		
     /**
      * Retrieve POI workbook referred to by current {@link WorkbookContext}.
      * Please refrain from using the exposed {@link HSSFWorkbook} directly unless you need functionality of POI not provided by {@link WorkbookContext}.

--- a/core/src/main/java/org/subtlelib/poi/impl/style/CompositeStyle.java
+++ b/core/src/main/java/org/subtlelib/poi/impl/style/CompositeStyle.java
@@ -21,7 +21,7 @@ public final class CompositeStyle implements AdditiveStyle {
 	private final ImmutableMap<Enum<?>, AdditiveStyle> styles;
 	
     public CompositeStyle(List<AdditiveStyle> partialStyles) {
-        Map<Enum<?>, AdditiveStyle> combined = new LinkedHashMap<>();
+        Map<Enum<?>, AdditiveStyle> combined = new LinkedHashMap<Enum<?>, AdditiveStyle>();
         for (AdditiveStyle partialStyle : partialStyles) {
             combined.put(partialStyle.getType(), partialStyle);
         }

--- a/core/src/main/java/org/subtlelib/poi/impl/workbook/WorkbookContextImpl.java
+++ b/core/src/main/java/org/subtlelib/poi/impl/workbook/WorkbookContextImpl.java
@@ -22,7 +22,7 @@ public class WorkbookContextImpl extends InheritableStyleConfiguration<WorkbookC
 
     private final HSSFWorkbook workbook;
     
-    private final Map<Style, HSSFCellStyle> registeredStyles = new HashMap<>();
+    private final Map<Style, HSSFCellStyle> registeredStyles = new HashMap<Style, HSSFCellStyle>();
     
     private final Configuration configuration;
     

--- a/core/src/test/java/org/subtlelib/poi/fixtures/AdditiveStyleTestImpl.java
+++ b/core/src/test/java/org/subtlelib/poi/fixtures/AdditiveStyleTestImpl.java
@@ -1,10 +1,10 @@
 package org.subtlelib.poi.fixtures;
 
-import java.util.Objects;
-
 import org.apache.poi.hssf.usermodel.HSSFCellStyle;
 import org.apache.poi.hssf.usermodel.HSSFWorkbook;
 import org.subtlelib.poi.api.style.AdditiveStyle;
+
+import com.google.common.base.Objects;
 
 public class AdditiveStyleTestImpl implements AdditiveStyle {
 
@@ -28,14 +28,14 @@ public class AdditiveStyleTestImpl implements AdditiveStyle {
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, type);
+        return Objects.hashCode(id, type);
     }
 
     @Override
     public boolean equals(Object obj) {
         if (obj instanceof AdditiveStyleTestImpl) {
             AdditiveStyleTestImpl that = (AdditiveStyleTestImpl) obj;
-            return Objects.equals(this.id, that.id) && Objects.equals(this.type, that.type);
+            return Objects.equal(this.id, that.id) && Objects.equal(this.type, that.type);
         }
         return false;
     }

--- a/core/src/test/java/org/subtlelib/poi/fixtures/NonAdditiveStyleTestImpl.java
+++ b/core/src/test/java/org/subtlelib/poi/fixtures/NonAdditiveStyleTestImpl.java
@@ -1,10 +1,10 @@
 package org.subtlelib.poi.fixtures;
 
-import java.util.Objects;
-
 import org.apache.poi.hssf.usermodel.HSSFCellStyle;
 import org.apache.poi.hssf.usermodel.HSSFWorkbook;
 import org.subtlelib.poi.api.style.Style;
+
+import com.google.common.base.Objects;
 
 public class NonAdditiveStyleTestImpl implements Style {
     private final String id;
@@ -20,12 +20,12 @@ public class NonAdditiveStyleTestImpl implements Style {
 
     @Override
     public int hashCode() {
-        return Objects.hash(id);
+        return Objects.hashCode(id);
     }
 
     @Override
     public boolean equals(Object obj) {
         return obj instanceof NonAdditiveStyleTestImpl
-                && Objects.equals(id, NonAdditiveStyleTestImpl.class.cast(obj).id);
+                && Objects.equal(id, NonAdditiveStyleTestImpl.class.cast(obj).id);
     }
 }


### PR DESCRIPTION
Using this change the library will be JDK 1.6 compatible and will run on JDK 1.6 too. 
I'm using guava's Objects... instead of JDK 1.7's Objects for hashcode and equals building.
